### PR TITLE
Fix: Prevent negative coordinates in center_to_corners_format

### DIFF
--- a/saltup/ai/object_detection/utils/bbox.py
+++ b/saltup/ai/object_detection/utils/bbox.py
@@ -204,14 +204,12 @@ def center_to_corners_format(box: Union[List, Tuple]) -> Tuple[float, float, flo
     if w < 0 or h < 0:
         raise ValueError("Width and height must be non-negative")
 
-    x1 = xc - w / 2
-    y1 = yc - h / 2
-    if x1 < 0:
-        x1 = 0.0
-    if y1 < 0:
-        y1 = 0.0
-    x2 = xc + w / 2
-    y2 = yc + h / 2
+    # Clamp coordinates
+    x1 = max(0, xc - w / 2)
+    y1 = max(0, yc - h / 2)
+    x2 = max(0, xc + w / 2)
+    y2 = max(0, yc + h / 2)
+    
     return x1, y1, x2, y2
 
 


### PR DESCRIPTION
This commit addresses an issue where the `center_to_corners_format` function could return negative coordinates for bounding boxes, causing them to extend outside the valid image boundaries.

Changes:
- Added clamping to ensure that the resulting coordinates (x1, y1, x2, y2) are non-negative.
- This prevents invalid bounding boxes from being generated when the center coordinates are close to the edges or when width/height are large.
- **Note:** Since image dimensions are not passed to the function, there is no control for coordinates exceeding the image boundaries. This means the bounding box may still extend beyond the image limits if the width or height is too large.

The fix ensures that the function always returns valid bounding box coordinates with non-negative values, even without explicit image dimensions.