### PR TITLE
refactor(yolo): simplify get_boxes method

### DIFF
--- a/saltup/ai/object_detection/utils/bbox.py
+++ b/saltup/ai/object_detection/utils/bbox.py
@@ -830,7 +830,6 @@ class BBox:
 
             if format == BBoxFormat.CORNERS:
                 if self.is_normalized(coordinates, format):
-                    # If the co-ordinates are normalized, convert them to absolute pixel values
                     self.__normalized_coordinates = coordinates
                 else:
                     # If the co-ordinates are not normalized, normalize them
@@ -838,7 +837,6 @@ class BBox:
 
             elif format == BBoxFormat.CENTER:
                 if self.is_normalized(coordinates, format):
-                    # If the co-ordinates are normalized, convert them to absolute pixel values
                     self.__normalized_coordinates = self.center_to_corners_format(coordinates)
                 else:
                     # If the co-ordinates are not normalized, normalize them
@@ -847,7 +845,6 @@ class BBox:
 
             elif format == BBoxFormat.TOPLEFT:
                 if self.is_normalized(coordinates, format):
-                    # If the co-ordinates are normalized, convert them to absolute pixel values
                     self.__normalized_coordinates = self.topleft_to_corners_format(coordinates)
                 else:
                     # If the co-ordinates are not normalized, normalize them

--- a/saltup/ai/object_detection/yolo/yolo.py
+++ b/saltup/ai/object_detection/yolo/yolo.py
@@ -9,7 +9,7 @@ import cv2
 from collections import defaultdict
 from abc import ABC, abstractmethod
 
-from saltup.ai.object_detection.utils.bbox  import BBox, BBoxFormat
+from saltup.ai.object_detection.utils.bbox  import BBox, BBoxFormat, NotationFormat
 from saltup.ai.object_detection.utils.metrics  import compute_ap, compute_map_50_95 , compute_ap_for_threshold
 from saltup.ai.object_detection.yolo.yolo_type  import YoloType
 from saltup.utils.data.image.image_utils import ColorMode ,ImageFormat
@@ -41,34 +41,17 @@ image        """
 
     tprocessing_time_ms = 0.0 
 
-    def get_boxes(self, format: Optional[BBoxFormat] = None) -> List[Tuple['BBox', int, float]]:
+    def get_boxes(self) -> List[Tuple['BBox', int, float]]:
         """
-        Get the list of bounding boxes in the specified format.
-
-        Args:
-            format: The desired format (CORNERS, CENTER, TOPLEFT). If None, leaves the format unchanged.
+        Get the list of bounding boxes.
 
         Returns:
             List of tuples containing:
-                - BBox objects with coordinates in the specified format (or current format if None).
+                - BBox coordinates in corner normalized.
                 - Class ID (int).
                 - Confidence score (float).
         """
-        formatted_boxes = []
-        for bbox, class_id, confidence in self._boxes:
-            if format is None or bbox.get_format() == format:
-                # If format is None or already matches, reuse the existing BBox object
-                formatted_boxes.append((bbox, class_id, confidence))
-            else:
-                # If the format is different, create a new BBox object in the desired format
-                new_bbox = BBox(
-                    coordinates=bbox.get_coordinates(format),
-                    format=format,
-                    img_width=bbox.img_width,
-                    img_height=bbox.img_height
-                )
-                formatted_boxes.append((new_bbox, class_id, confidence))
-        return formatted_boxes
+        return self._boxes
     
     def set_boxes(self, boxes: List[BBox]):
         """

--- a/saltup/tools/yolo_inference.py
+++ b/saltup/tools/yolo_inference.py
@@ -235,7 +235,7 @@ def main(args=None):
             if args.gui:               
                 # Draw bounding boxes on the image
                 image_with_boxes = draw_boxes_on_image_with_labels_score(image, 
-                                                                        yoloOut.get_boxes(format=BBoxFormat.CORNERS),
+                                                                        yoloOut.get_boxes(),
                                                                         class_colors_bgr=class_colors_dict,
                                                                         class_labels=class_labels_dict)
                 
@@ -272,8 +272,6 @@ def main(args=None):
     print(f"  - Recall: {metric.getRecall():.4f}")
     print(f"  - F1 Score: {metric.getF1Score():.4f}")
     
-
-
 
 if __name__ == "__main__":
     main()

--- a/test/ai/object_detection/utils/test_yolo_output.py
+++ b/test/ai/object_detection/utils/test_yolo_output.py
@@ -1,0 +1,66 @@
+import pytest
+from typing import List, Tuple, Optional
+import numpy as np
+from saltup.ai.object_detection.yolo.yolo import YoloOutput
+from saltup.ai.object_detection.utils.bbox  import BBox, BBoxFormat, NotationFormat
+from saltup.utils.data.image.image_utils import Image
+
+
+def test_yolo_output():
+    # Test constructor
+    boxes = [(BBox(100, 100, (10, 20, 30, 40)), 1, 0.9)]
+    image = Image(np.zeros((100, 100, 3)))
+    yolo_output = YoloOutput(boxes, image)
+    
+    # Test get_boxes
+    assert yolo_output.get_boxes() == boxes
+    
+    # Test set_boxes
+    new_boxes = [(BBox(100, 100, (50, 60, 70, 80)), 2, 0.8)]
+    yolo_output.set_boxes(new_boxes)
+    assert yolo_output.get_boxes() == new_boxes
+    
+    # Test get_image
+    assert np.array_equal(yolo_output.get_image(), image)
+    
+    # Test set_image
+    new_image = Image(np.ones((50, 50, 3)))
+    yolo_output.set_image(new_image)
+    assert np.array_equal(yolo_output.get_image(), new_image)
+    
+    # Test inference time
+    yolo_output.set_inference_time(50.5)
+    assert yolo_output.get_inference_time() == 50.5
+    
+    # Test preprocessing time
+    yolo_output.set_preprocessing_time(20.2)
+    assert yolo_output.get_preprocessing_time() == 20.2
+    
+    # Test postprocessing time
+    yolo_output.set_postprocessing_time(30.3)
+    assert yolo_output.get_postprocessing_time() == 30.3
+    
+    # Test total processing time
+    assert yolo_output.get_total_processing_time() == 50.5 + 20.2 + 30.3
+    
+    # Test get_property
+    assert yolo_output.get_property("boxes") == new_boxes
+    assert yolo_output.get_property("image") == new_image
+    assert yolo_output.get_property("inference_time") == 50.5
+    assert yolo_output.get_property("preprocessing_time") == 20.2
+    assert yolo_output.get_property("postprocessing_time") == 30.3
+    with pytest.raises(AttributeError):
+        yolo_output.get_property("invalid_property")
+    
+    # Test set_property
+    yolo_output.set_property("inference_time", 99.9)
+    assert yolo_output.get_inference_time() == 99.9
+    
+    yolo_output.set_property("preprocessing_time", 10.1)
+    assert yolo_output.get_preprocessing_time() == 10.1
+    
+    with pytest.raises(AttributeError):
+        yolo_output.set_property("invalid_property", 123)
+    
+    # Test __repr__
+    assert "YoloOutput" in repr(yolo_output)


### PR DESCRIPTION
**refinements to the YOLO output processing and bounding box handling**

**Updated YoloOutput Class (yolo.py)**

- Removed the optional format conversion from get_boxes(), ensuring that bounding boxes are always returned in a consistent format.
- Added an import for NotationFormat to yolo.py.

**Modified yolo_inference.py**

- Updated calls to get_boxes(), removing the unused format=BBoxFormat.CORNERS argument to align with the new method signature.

**New Test Suite for YoloOutput (test_yolo_output.py)**

- Introduced a unit test file to validate:
- Bounding box retrieval and modification.
- Image association.
- Inference, preprocessing, and postprocessing times.
- Property getters and setters.
- Error handling for invalid properties.
