### PR TITLE
Additional generic video & audio analysis utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ CLAUDE.md
 # Test and sample models
 test/ai/nn_manager/sample_models/*
 test/tests_data/models/*
+
+# env
+env/

--- a/saltup/utils/data/audio/__init__.py
+++ b/saltup/utils/data/audio/__init__.py
@@ -1,0 +1,1 @@
+from .audio_utils import *  # noqa: F401,F403

--- a/saltup/utils/data/audio/audio_utils.py
+++ b/saltup/utils/data/audio/audio_utils.py
@@ -1,0 +1,216 @@
+"""
+Audio loading utilities for the saltup library.
+
+This module provides generic functions for loading audio data from files
+and in-memory byte streams.  It supports both encoded formats (wav, mp3,
+flac, …) via ``librosa`` and headerless raw PCM.
+
+**Dependency note** — ``librosa`` is an *optional* dependency
+(part of the ``saltup[full]`` extra).  Functions in this module raise
+a clear ``ImportError`` at call time if ``librosa`` is not installed,
+keeping the base ``saltup`` package lightweight.
+
+Typical usage::
+
+    from saltup.utils.data.audio.audio_utils import load_audio, load_audio_from_stream
+
+    audio, sr = load_audio("recording.wav", sr=44100)
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy librosa import — fail gracefully at call time, not at module import.
+# ---------------------------------------------------------------------------
+
+_librosa = None
+
+
+def _ensure_librosa():
+    """Import librosa on first use and cache the reference. Reduce overhead for users who don't need it."""
+    global _librosa
+    if _librosa is None:
+        try:
+            import librosa
+            _librosa = librosa
+        except ImportError as exc:
+            raise ImportError(
+                "librosa is required for audio processing utilities. "
+                "Install it with:  pip install saltup[full]  or  pip install librosa"
+            ) from exc
+    return _librosa
+
+
+# =============================================================================
+# Audio Loading
+# =============================================================================
+
+def load_audio(
+    audio_path: str,
+    sr: int = 44100,
+    is_raw: bool = False,
+    raw_format: str = "int16",
+    n_channels: int = 1,
+    downsample: bool = False,
+    target_sr: int = 16000,
+) -> Tuple[np.ndarray, int]:
+    """Load an audio file and return the waveform as a 1-D float array.
+
+    Supports two modes:
+
+    * **Encoded files** (wav, mp3, flac, …) — decoded via ``librosa.load``.
+    * **Raw headerless files** — read directly from disk as a flat
+      binary blob with the specified ``raw_format``.
+
+    In both cases the returned array is mono, float32-normalised to the
+    range ``[-1, 1]``.
+
+    Args:
+        audio_path: Path to the audio file.
+        sr: Target sample rate in Hz.  ``librosa.load`` will resample
+            automatically.  For raw files this is the *assumed* original
+            sample rate.  Defaults to 44 100.
+        is_raw: If ``True``, treat the file as headerless raw PCM.
+            Defaults to ``False``.
+        raw_format: NumPy dtype string for raw files (e.g. ``"int16"``,
+            ``"int32"``, ``"float32"``).  Ignored when ``is_raw`` is
+            ``False``.  Defaults to ``"int16"``.
+        n_channels: Number of interleaved channels in the raw file.
+            Multi-channel data is averaged to mono.  Defaults to 1.
+        downsample: If ``True``, resample the audio to *target_sr*
+            after loading.  Defaults to ``False``.
+        target_sr: Target sample rate when *downsample* is ``True``.
+            Defaults to 16 000.
+
+    Returns:
+        A tuple ``(audio_data, sample_rate)`` where *audio_data* is a
+        1-D ``float32`` NumPy array and *sample_rate* is the effective
+        sample rate after any downsampling.
+
+    Raises:
+        IOError: If the file cannot be read or decoded.
+
+    Examples:
+        >>> y, sr = load_audio("speech.wav", sr=16000)
+        >>> y.dtype
+        dtype('float32')
+    """
+    librosa = _ensure_librosa()
+
+    try:
+        if is_raw:
+            audio_data = np.fromfile(audio_path, dtype=raw_format)
+
+            # De-interleave multi-channel data
+            if n_channels > 1:
+                audio_data = audio_data.reshape(-1, n_channels)
+
+            # Normalise integer formats to [-1, 1]
+            audio_data = _normalise_pcm(audio_data, raw_format)
+
+            # Mix to mono
+            if n_channels > 1:
+                audio_data = np.mean(audio_data, axis=1)
+
+            # Optional downsampling
+            if downsample and target_sr < sr:
+                audio_data = librosa.resample(audio_data, orig_sr=sr, target_sr=target_sr)
+                sr = target_sr
+                logger.info("Downsampled raw audio to %d Hz", target_sr)
+
+            logger.info(
+                "Loaded raw audio: %d samples, %d channel(s) at %d Hz",
+                len(audio_data), n_channels, sr,
+            )
+            return audio_data, sr
+
+        else:
+            # librosa handles mp3, wav, flac, ogg, …
+            y, sr_loaded = librosa.load(audio_path, sr=sr, mono=True)
+
+            if downsample and target_sr < sr:
+                y = librosa.resample(y, orig_sr=sr, target_sr=target_sr)
+                sr = target_sr
+                logger.info("Downsampled audio to %d Hz", target_sr)
+
+            logger.info("Loaded audio: %d samples at %d Hz", len(y), sr)
+            return y, sr
+
+    except Exception as exc:
+        raise IOError(f"Cannot load audio file {audio_path}: {exc}") from exc
+
+
+def load_audio_from_stream(
+    stream: io.RawIOBase,
+    sr: int = 44100,
+    raw_format: str = "int16",
+    n_channels: int = 1,
+) -> Tuple[np.ndarray, int]:
+    """Load raw audio from an in-memory byte stream (e.g. from MinIO / S3).
+
+    The stream is consumed in a single ``read()`` call and interpreted as
+    headerless PCM with the specified format and channel layout.
+
+    Args:
+        stream: A file-like or ``BytesIO`` object containing raw audio
+            bytes.
+        sr: Assumed sample rate of the raw data.  Defaults to 44 100.
+        raw_format: NumPy dtype for the raw samples.  Defaults to
+            ``"int16"``.
+        n_channels: Number of interleaved channels.  Defaults to 1.
+
+    Returns:
+        ``(audio_data, sample_rate)`` — same convention as
+        :func:`load_audio`.
+
+    Raises:
+        IOError: If the stream cannot be decoded.
+
+    Examples:
+        >>> import io
+        >>> buf = io.BytesIO(b"\\x00" * 1000)
+        >>> y, sr = load_audio_from_stream(buf, sr=16000)
+    """
+    try:
+        audio_bytes = stream.read()
+        audio_data = np.frombuffer(audio_bytes, dtype=raw_format)
+
+        if n_channels > 1:
+            audio_data = audio_data.reshape(-1, n_channels)
+
+        audio_data = _normalise_pcm(audio_data, raw_format)
+
+        if n_channels > 1:
+            audio_data = np.mean(audio_data, axis=1)
+
+        logger.info(
+            "Loaded audio from stream: %d samples at %d Hz",
+            len(audio_data), sr,
+        )
+        return audio_data, sr
+
+    except Exception as exc:
+        raise IOError(f"Cannot load audio from stream: {exc}") from exc
+
+
+# =============================================================================
+# Private Helpers
+# =============================================================================
+
+def _normalise_pcm(audio_data: np.ndarray, raw_format: str) -> np.ndarray:
+    """Normalise integer PCM data to float32 in [-1, 1]."""
+    if raw_format == "int16":
+        return audio_data.astype(np.float32) / 32768.0
+    elif raw_format == "int32":
+        return audio_data.astype(np.float32) / 2147483648.0
+    # float32 or other formats: return as-is
+    return audio_data.astype(np.float32)
+

--- a/saltup/utils/data/video/__init__.py
+++ b/saltup/utils/data/video/__init__.py
@@ -1,1 +1,1 @@
-from .video_utils import *
+from .video_utils import *  # noqa: F401,F403

--- a/saltup/utils/data/video/video_utils.py
+++ b/saltup/utils/data/video/video_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path, PurePosixPath
 import subprocess
 from typing import Callable, Dict, Tuple, Union, List, Optional
 from urllib.parse import urlparse
-from saltup.utils.misc import is_url, compute_weighted_average
+from saltup.utils.misc import is_url
 from saltup.utils.data.image.image_utils import ColorMode, ColorsBGR, Image, ImageFormat
 
 # =============================================================================
@@ -260,28 +260,6 @@ def get_video_properties(video_path: Union[str, Path]) -> tuple[float, int, int,
 
     video.release()
     return fps, total_frames, width, height
- 
-# def get_video_properties(video_path: Union[str, Path]):
-#     """
-#     Get video properties such as FPS, total frames, width, and height.
-
-#     Args:
-#         video_path: Path to the video file.
-
-#     Returns:
-#         A tuple containing (fps, total_frames, width, height).
-#     """
-#     video = cv2.VideoCapture(str(video_path))
-#     if not video.isOpened():
-#         raise FileNotFoundError(f"Unable to open video: {video_path}")
-
-#     fps = video.get(cv2.CAP_PROP_FPS)
-#     total_frames = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
-#     width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
-#     height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
-
-#     video.release()
-#     return fps, total_frames, width, height
 
 def _infer_codec_from_filename(filename: Union[str, Path]) -> str:
     """
@@ -493,12 +471,11 @@ def _quadrant_names(n_quadrants: int) -> List[str]:
     """
     return [f"quadrant_{i + 1}" for i in range(n_quadrants)]
 
-
 # =============================================================================
-# Quadrant Energy Analysis
+# Quadrant Intensity Analysis
 # =============================================================================
 
-def extract_quadrant_energy_intensity(
+def extract_quadrant_intensity(
     frames: List[np.ndarray],
     n_quadrants: int = 4,
 ) -> Dict[int, Dict[str, float]]:
@@ -528,10 +505,10 @@ def extract_quadrant_energy_intensity(
     Examples:
         >>> import numpy as np
         >>> white = np.ones((100, 100), dtype=np.uint8) * 255
-        >>> result = extract_quadrant_energy([white])
+        >>> result = extract_quadrant_intensity([white])
         >>> result[0]['quadrant_1']
         255.0
-        >>> result_9 = extract_quadrant_energy([white], n_quadrants=9)
+        >>> result_9 = extract_quadrant_intensity([white], n_quadrants=9)
         >>> len(result_9[0])
         9
     """
@@ -568,15 +545,14 @@ def extract_quadrant_energy_intensity(
     return energies
 
 
-def extract_quadrant_energy_intensity_diff(
+def extract_quadrant_motion(
     frames: List[np.ndarray],
     n_quadrants: int = 4,
 ) -> Dict[int, Dict[str, float]]:
-    """Compute per-frame energy using absolute frame differences.
-
-    Instead of raw pixel intensity (see :func:`extract_quadrant_energy`),
+    """Compute per-frame intensity using absolute frame differences.
+    Instead of raw pixel intensity (see :func:`extract_quadrant_intensity`),
     this function measures *change* between consecutive frames.  The
-    first frame always yields zero energy (no previous frame to diff
+    first frame always yields zero intensity (no previous frame to diff
     against).  This approach reduces sensitivity to slow global
     illumination changes and highlights motion.
 
@@ -586,7 +562,7 @@ def extract_quadrant_energy_intensity_diff(
         n_quadrants: Number of spatial regions (2–16).  Defaults to 4.
 
     Returns:
-        Same structure as :func:`extract_quadrant_energy` but values
+        Same structure as :func:`extract_quadrant_intensity` but values
         represent the mean absolute difference per quadrant.
 
     Raises:
@@ -630,89 +606,115 @@ def extract_quadrant_energy_intensity_diff(
 
 
 # =============================================================================
-# Variance Segment Extraction & Artifact Removal
+# Windowed Segment Aggregation & Filtering
 # =============================================================================
 
-def extract_variance_segments(
-    quad_variances: Dict[str, np.ndarray],
+def compute_windowed_segment_stats(
+    signal: np.ndarray,
     segments: List[Tuple[float, float]],
     fps: float,
     window_size_seconds: float = 10.0,
+    agg_fn: Optional[Callable[[np.ndarray], float]] = None,
 ) -> List[np.ndarray]:
-    """Extract windowed average variance arrays for each activity segment.
+    """Downsample a per-frame signal within each time segment.
 
-    For every segment the per-quadrant variances are averaged frame by
-    frame, then downsampled by computing the weighted average over
-    non-overlapping windows of *window_size_seconds*.
+    For every ``(start, end)`` segment the function slices the
+    corresponding frames from *signal*, splits them into
+    non-overlapping windows of *window_size_seconds*, and reduces each
+    window to a single scalar via *agg_fn*.
+
+    This is a generic building block — it knows nothing about quadrants
+    or variance; it simply aggregates any 1-D per-frame signal over
+    time windows.
 
     Args:
-        quad_variances: Per-quadrant variance arrays (from
-            :func:`detect_activity_segments`).
-        segments: List of ``(start_seconds, end_seconds)`` tuples.
-        fps: Video frame rate.
-        window_size_seconds: Duration (seconds) of each averaging
-            window.  Defaults to 10.0.
+        signal: 1-D NumPy array of per-frame values (length = total
+            number of frames in the source video).
+        segments: List of ``(start_seconds, end_seconds)`` tuples
+            defining the time intervals to process.
+        fps: Video frame rate (frames per second).
+        window_size_seconds: Duration (seconds) of each non-overlapping
+            aggregation window.  Defaults to 10.0.
+        agg_fn: Callable that reduces a 1-D window array to a single
+            float.  Receives an ``np.ndarray`` and must return a float.
+            Defaults to ``np.mean`` when ``None``.
 
     Returns:
-        A list of 1-D NumPy arrays, one per segment, containing the
-        windowed average variance values.
+        A list of 1-D NumPy arrays (one per segment) containing the
+        aggregated values.
+
+    Examples:
+        >>> import numpy as np
+        >>> # 300 frames at 30 fps = 10 seconds of data
+        >>> signal = np.random.rand(300)
+        >>> segments = [(0.0, 10.0)]
+        >>> result = compute_windowed_segment_stats(signal, segments, fps=30, window_size_seconds=5.0)
+        >>> len(result)          # one segment
+        1
+        >>> result[0].shape[0]   # 10s / 5s = 2 windows
+        2
     """
-    # Discover quadrant names from the variance dict keys
-    quad_names = sorted(quad_variances.keys())
-    window_size_frames = int(window_size_seconds * fps)
-    variance_segments: List[np.ndarray] = []
+    if agg_fn is None:
+        agg_fn = lambda w: float(np.mean(w))
+
+    window_size_frames = max(1, int(window_size_seconds * fps))
+    results: List[np.ndarray] = []
 
     for start, end in segments:
-        frame_variances: List[float] = []
-        for frame_idx in range(int(start * fps), int(end * fps) + 1):
-            # Average the four quadrants at this frame
-            qvals = [quad_variances[qn][frame_idx] for qn in quad_names]
-            frame_variances.append(float(np.mean(qvals)))
+        start_frame = int(start * fps)
+        end_frame = min(int(end * fps) + 1, len(signal))
 
-        if not frame_variances:
+        segment_data = signal[start_frame:end_frame]
+        if len(segment_data) == 0:
             continue
 
-        # Downsample with windowed weighted average
-        segment_arr = np.asarray(frame_variances, dtype=np.float64)
-        averaged: List[float] = []
-        for win_start in range(0, len(segment_arr), window_size_frames):
-            window = segment_arr[win_start : win_start + window_size_frames]
+        aggregated: List[float] = []
+        for win_start in range(0, len(segment_data), window_size_frames):
+            window = segment_data[win_start : win_start + window_size_frames]
             if len(window) > 0:
-                averaged.append(compute_weighted_average(window))
+                aggregated.append(agg_fn(window))
 
-        variance_segments.append(np.array(averaged))
+        results.append(np.array(aggregated))
 
-    return variance_segments
+    return results
 
 
-def remove_artifact_segments(
+def filter_segments_by_std(
     segments: List[Tuple[float, float]],
-    variance_segments: List[np.ndarray],
-    std_threshold: float = 0.0001,
+    segment_signals: List[np.ndarray],
+    std_threshold: float = 0.01,
 ) -> Tuple[List[Tuple[float, float]], List[np.ndarray]]:
-    """Filter out segments whose variance profile is nearly constant.
+    """Discard segments whose associated signal has low variability.
 
-    Segments with a standard deviation below *std_threshold* across all
-    windowed variance values are considered artifacts (e.g. static noise
-    or sensor glitches) and are removed.
+    Pairs of ``(segment, signal)`` are dropped when the standard
+    deviation of *signal* falls below *std_threshold*.  This is useful
+    for removing near-constant regions that are unlikely to contain
+    meaningful activity.
 
     Args:
         segments: Time segments as ``(start, end)`` tuples.
-        variance_segments: Corresponding variance arrays from
-            :func:`extract_variance_segments`.
+        segment_signals: One 1-D NumPy array per segment (e.g. output
+            of :func:`compute_windowed_segment_stats`).
         std_threshold: Minimum standard deviation to keep a segment.
-            Defaults to 0.0001.
+            Defaults to 0.01.
 
     Returns:
-        A 2-tuple ``(filtered_segments, filtered_variances)`` with the
-        artifact-free data.
+        A 2-tuple ``(kept_segments, kept_signals)``.
+
+    Examples:
+        >>> import numpy as np
+        >>> segs = [(0, 10), (20, 30)]
+        >>> sigs = [np.array([0.5, 0.5, 0.5]), np.array([0.1, 0.9, 0.3])]
+        >>> kept_segs, kept_sigs = filter_segments_by_std(segs, sigs, std_threshold=0.1)
+        >>> len(kept_segs)  # first segment (constant) is dropped
+        1
     """
-    filtered_segments: List[Tuple[float, float]] = []
-    filtered_variances: List[np.ndarray] = []
+    kept_segments: List[Tuple[float, float]] = []
+    kept_signals: List[np.ndarray] = []
 
-    for i, var_seg in enumerate(variance_segments):
-        if np.std(var_seg) >= std_threshold:
-            filtered_segments.append(segments[i])
-            filtered_variances.append(var_seg)
+    for i, sig in enumerate(segment_signals):
+        if np.std(sig) >= std_threshold:
+            kept_segments.append(segments[i])
+            kept_signals.append(sig)
 
-    return filtered_segments, filtered_variances
+    return kept_segments, kept_signals

--- a/saltup/utils/data/video/video_utils.py
+++ b/saltup/utils/data/video/video_utils.py
@@ -1,10 +1,20 @@
 import os
 import cv2
 import numpy as np
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import subprocess
-from typing import Callable, Union , List, Optional
+from typing import Callable, Dict, Tuple, Union, List, Optional
+from urllib.parse import urlparse
+from saltup.utils.misc import is_url, compute_weighted_average
 from saltup.utils.data.image.image_utils import ColorMode, ColorsBGR, Image, ImageFormat
+
+# =============================================================================
+# Module Constants
+# =============================================================================
+
+_MIN_QUADRANTS = 2
+_MAX_QUADRANTS = 16
+
 
 def create_avi_from_jpg(folder: str, output_filename: str, fps: int = 4) -> None:
     """
@@ -177,23 +187,36 @@ def get_video_properties(video_path: Union[str, Path]) -> tuple[float, int, int,
 
     """
     Get video properties such as FPS, total frames, width, and height.
-    - For .ts files, FPS is calculated manually using frame timestamps and rounded to the nearest integer.
+    Supports both local file paths and HTTP/HTTPS URLs (e.g. S3 presigned URLs).
+    OpenCV uses FFmpeg internally, so URLs are opened directly without downloading.
+    - For .ts files (local or remote), FPS is calculated manually using frame timestamps.
     - For other formats, use OpenCV's default implementation.
-    tuple: A tuple containing (fps, total_frames, width, height).
-        float: The FPS (frames per second).
-        int: The total number of frames.
-        int: The width of the video.
-        int: The height of the video.
+
+    Args:
+        video_path: Local file path or HTTP/HTTPS URL (e.g. S3 presigned URL).
+
+    Returns:
+        tuple: A tuple containing (fps, total_frames, width, height).
+            float: The FPS (frames per second).
+            int: The total number of frames.
+            int: The width of the video.
+            int: The height of the video.
     """
-    video_path = Path(video_path)
-    if not video_path.exists():
-        raise FileNotFoundError(f"Video file not found: {video_path}")
+    _is_url = is_url(video_path)
+
+    if _is_url:
+        video_source = video_path
+    else:
+        video_path = Path(video_path)
+        if not video_path.exists():
+            raise FileNotFoundError(f"Video file not found: {video_path}")
+        video_source = str(video_path)
 
     # List of formats that require manual FPS calculation
     custom_formats = ['.ts']
 
-    # Open the video
-    video = cv2.VideoCapture(str(video_path))
+    # Open the video (OpenCV uses FFmpeg internally, supports both files and URLs)
+    video = cv2.VideoCapture(video_source)
     if not video.isOpened():
         raise RuntimeError(f"Unable to open video: {video_path}")
 
@@ -201,8 +224,15 @@ def get_video_properties(video_path: Union[str, Path]) -> tuple[float, int, int,
     width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
     height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
+    # Determine the file suffix (for URLs, extract from the path portion before query params)
+    if _is_url:
+        url_path = urlparse(str(video_path)).path
+        suffix = PurePosixPath(url_path).suffix.lower()
+    else:
+        suffix = Path(video_path).suffix.lower()
+
     # If the format is in the custom_formats list, manually calculate FPS and total_frames
-    if video_path.suffix.lower() in custom_formats:
+    if suffix in custom_formats:
         total_frames = 0
         frame_timestamps = []  # Store frame timestamps to calculate FPS
         while True:
@@ -331,3 +361,329 @@ def process_video(
     input_video.release()
     if out is not None:
         out.release()
+
+
+# =============================================================================
+# Frame Preprocessing
+# =============================================================================
+
+def preprocess_frame(
+    frame: np.ndarray,
+    resize: Optional[Tuple[int, int]] = None,
+    gray: bool = True,
+    blur: Optional[Tuple[int, int]] = None,
+    normalize: bool = False,
+) -> np.ndarray:
+    """Apply a configurable preprocessing pipeline to a single video frame.
+
+    Operations are applied in order: resize → grayscale → blur → normalize.
+    Each step is optional and controlled by its corresponding argument.
+
+    Args:
+        frame: Input frame as a BGR NumPy array (H×W×3).
+        resize: Target ``(width, height)`` for resizing.  ``None`` skips
+            resizing.  Defaults to ``None``.
+        gray: If ``True``, convert the frame to single-channel grayscale.
+            Defaults to ``True``.
+        blur: Gaussian blur kernel size as ``(kW, kH)`` (both must be odd).
+            ``None`` skips blurring.  Defaults to ``None``.
+        normalize: If ``True``, apply z-score normalization rescaled to
+            the 0–255 uint8 range (mean ≈ 128, std ≈ 32).  Useful for
+            reducing sensitivity to global illumination changes.
+            Defaults to ``False``.
+
+    Returns:
+        The preprocessed frame as a NumPy array.
+
+    Examples:
+        >>> import cv2, numpy as np
+        >>> frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        >>> gray_small = preprocess_frame(frame, resize=(320, 240), gray=True)
+        >>> gray_small.shape
+        (240, 320)
+    """
+    if resize is not None:
+        frame = cv2.resize(frame, resize, interpolation=cv2.INTER_LINEAR)
+    if gray:
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    if blur is not None:
+        frame = cv2.GaussianBlur(frame, blur, 0)
+    if normalize:
+        frame_f = frame.astype(np.float32)
+        mean = float(np.mean(frame_f))
+        std = float(np.std(frame_f))
+        if std > 1e-6:
+            norm = (frame_f - mean) / std
+            frame = np.clip(128.0 + 32.0 * norm, 0, 255).astype(np.uint8)
+    return frame
+
+
+# =============================================================================
+# Quadrant Grid Helpers
+# =============================================================================
+
+
+def _compute_grid(n_quadrants: int) -> Tuple[int, int]:
+    """Find the most square-like (rows, cols) grid for *n_quadrants*.
+
+    The function returns the pair ``(rows, cols)`` where
+    ``rows * cols == n_quadrants`` and the difference ``|rows - cols|``
+    is minimised.
+
+    Args:
+        n_quadrants: Desired number of spatial regions (2–16).
+
+    Returns:
+        ``(rows, cols)`` tuple.
+
+    Raises:
+        ValueError: If *n_quadrants* is outside the 2–16 range.
+    """
+    if not (_MIN_QUADRANTS <= n_quadrants <= _MAX_QUADRANTS):
+        raise ValueError(
+            f"n_quadrants must be between {_MIN_QUADRANTS} and "
+            f"{_MAX_QUADRANTS}, got {n_quadrants}."
+        )
+    best = (1, n_quadrants)
+    for r in range(1, int(n_quadrants ** 0.5) + 1):
+        if n_quadrants % r == 0:
+            c = n_quadrants // r
+            if abs(r - c) < abs(best[0] - best[1]):
+                best = (r, c)
+    return best
+
+
+def _quadrant_names(n_quadrants: int) -> List[str]:
+    """Return a list of canonical quadrant key names.
+
+    Keys are ``'quadrant_1'`` … ``'quadrant_N'`` where *N* equals
+    *n_quadrants*.  The ordering follows a **row-major, bottom-to-top**
+    scan: the first quadrant is the bottom-right cell of the grid, and
+    the last is the top-left cell.  For ``n_quadrants=4`` this matches
+    the legacy numbering.
+    """
+    return [f"quadrant_{i + 1}" for i in range(n_quadrants)]
+
+
+# =============================================================================
+# Quadrant Energy Analysis
+# =============================================================================
+
+def extract_quadrant_energy_intensity(
+    frames: List[np.ndarray],
+    n_quadrants: int = 4,
+) -> Dict[int, Dict[str, float]]:
+    """Compute per-frame average pixel intensity in each spatial quadrant.
+
+    The frame is divided into a ``rows × cols`` grid whose total cell
+    count equals *n_quadrants*.  The grid shape is chosen to be as
+    square as possible (see :func:`_compute_grid`).
+
+    Quadrants are labelled ``'quadrant_1'`` … ``'quadrant_N'`` following
+    a **row-major, bottom-to-top** scan (bottom-right first, top-left
+    last).  For ``n_quadrants=4`` this is identical to the legacy
+    convention.
+
+    Args:
+        frames: List of preprocessed frames (grayscale or colour NumPy
+            arrays).  All frames must share the same spatial dimensions.
+        n_quadrants: Number of spatial regions (2–16).  Defaults to 4.
+
+    Returns:
+        Dictionary mapping each frame index to a sub-dictionary of
+        quadrant names → float energy values.
+
+    Raises:
+        ValueError: If *n_quadrants* is outside the 2–16 range.
+
+    Examples:
+        >>> import numpy as np
+        >>> white = np.ones((100, 100), dtype=np.uint8) * 255
+        >>> result = extract_quadrant_energy([white])
+        >>> result[0]['quadrant_1']
+        255.0
+        >>> result_9 = extract_quadrant_energy([white], n_quadrants=9)
+        >>> len(result_9[0])
+        9
+    """
+    rows, cols = _compute_grid(n_quadrants)
+    names = _quadrant_names(n_quadrants)
+
+    if not frames:
+        return {}
+
+    h, w = frames[0].shape[:2]
+    n_frames = len(frames)
+
+    # Pre-compute row/col boundaries once
+    row_edges = [int(round(r * h / rows)) for r in range(rows + 1)]
+    col_edges = [int(round(c * w / cols)) for c in range(cols + 1)]
+
+    # Pre-allocate one array per cell
+    cell_arrays = [np.zeros(n_frames, dtype=np.float32) for _ in range(n_quadrants)]
+
+    for i, frame in enumerate(frames):
+        # Fill cells in bottom-to-top, right-to-left order to match legacy naming
+        cell_idx = 0
+        for r in reversed(range(rows)):
+            for c in reversed(range(cols)):
+                cell_arrays[cell_idx][i] = np.mean(
+                    frame[row_edges[r]:row_edges[r + 1], col_edges[c]:col_edges[c + 1]]
+                )
+                cell_idx += 1
+
+    energies: Dict[int, Dict[str, float]] = {
+        i: {name: float(cell_arrays[ci][i]) for ci, name in enumerate(names)}
+        for i in range(n_frames)
+    }
+    return energies
+
+
+def extract_quadrant_energy_intensity_diff(
+    frames: List[np.ndarray],
+    n_quadrants: int = 4,
+) -> Dict[int, Dict[str, float]]:
+    """Compute per-frame energy using absolute frame differences.
+
+    Instead of raw pixel intensity (see :func:`extract_quadrant_energy`),
+    this function measures *change* between consecutive frames.  The
+    first frame always yields zero energy (no previous frame to diff
+    against).  This approach reduces sensitivity to slow global
+    illumination changes and highlights motion.
+
+    Args:
+        frames: List of preprocessed frames.  All frames must share the
+            same spatial dimensions.
+        n_quadrants: Number of spatial regions (2–16).  Defaults to 4.
+
+    Returns:
+        Same structure as :func:`extract_quadrant_energy` but values
+        represent the mean absolute difference per quadrant.
+
+    Raises:
+        ValueError: If *n_quadrants* is outside the 2–16 range.
+    """
+    rows, cols = _compute_grid(n_quadrants)
+    names = _quadrant_names(n_quadrants)
+
+    if not frames:
+        return {}
+
+    h, w = frames[0].shape[:2]
+    n_frames = len(frames)
+
+    row_edges = [int(round(r * h / rows)) for r in range(rows + 1)]
+    col_edges = [int(round(c * w / cols)) for c in range(cols + 1)]
+
+    cell_arrays = [np.zeros(n_frames, dtype=np.float32) for _ in range(n_quadrants)]
+
+    prev = frames[0]
+    for i in range(n_frames):
+        frame = frames[i]
+        diff = np.zeros_like(frame) if i == 0 else cv2.absdiff(frame, prev)
+
+        # Bottom-to-top, right-to-left scan (matches legacy naming)
+        cell_idx = 0
+        for r in reversed(range(rows)):
+            for c in reversed(range(cols)):
+                cell_arrays[cell_idx][i] = np.mean(
+                    diff[row_edges[r]:row_edges[r + 1], col_edges[c]:col_edges[c + 1]]
+                )
+                cell_idx += 1
+        prev = frame
+
+    energies: Dict[int, Dict[str, float]] = {
+        i: {name: float(cell_arrays[ci][i]) for ci, name in enumerate(names)}
+        for i in range(n_frames)
+    }
+    return energies
+
+
+
+# =============================================================================
+# Variance Segment Extraction & Artifact Removal
+# =============================================================================
+
+def extract_variance_segments(
+    quad_variances: Dict[str, np.ndarray],
+    segments: List[Tuple[float, float]],
+    fps: float,
+    window_size_seconds: float = 10.0,
+) -> List[np.ndarray]:
+    """Extract windowed average variance arrays for each activity segment.
+
+    For every segment the per-quadrant variances are averaged frame by
+    frame, then downsampled by computing the weighted average over
+    non-overlapping windows of *window_size_seconds*.
+
+    Args:
+        quad_variances: Per-quadrant variance arrays (from
+            :func:`detect_activity_segments`).
+        segments: List of ``(start_seconds, end_seconds)`` tuples.
+        fps: Video frame rate.
+        window_size_seconds: Duration (seconds) of each averaging
+            window.  Defaults to 10.0.
+
+    Returns:
+        A list of 1-D NumPy arrays, one per segment, containing the
+        windowed average variance values.
+    """
+    # Discover quadrant names from the variance dict keys
+    quad_names = sorted(quad_variances.keys())
+    window_size_frames = int(window_size_seconds * fps)
+    variance_segments: List[np.ndarray] = []
+
+    for start, end in segments:
+        frame_variances: List[float] = []
+        for frame_idx in range(int(start * fps), int(end * fps) + 1):
+            # Average the four quadrants at this frame
+            qvals = [quad_variances[qn][frame_idx] for qn in quad_names]
+            frame_variances.append(float(np.mean(qvals)))
+
+        if not frame_variances:
+            continue
+
+        # Downsample with windowed weighted average
+        segment_arr = np.asarray(frame_variances, dtype=np.float64)
+        averaged: List[float] = []
+        for win_start in range(0, len(segment_arr), window_size_frames):
+            window = segment_arr[win_start : win_start + window_size_frames]
+            if len(window) > 0:
+                averaged.append(compute_weighted_average(window))
+
+        variance_segments.append(np.array(averaged))
+
+    return variance_segments
+
+
+def remove_artifact_segments(
+    segments: List[Tuple[float, float]],
+    variance_segments: List[np.ndarray],
+    std_threshold: float = 0.0001,
+) -> Tuple[List[Tuple[float, float]], List[np.ndarray]]:
+    """Filter out segments whose variance profile is nearly constant.
+
+    Segments with a standard deviation below *std_threshold* across all
+    windowed variance values are considered artifacts (e.g. static noise
+    or sensor glitches) and are removed.
+
+    Args:
+        segments: Time segments as ``(start, end)`` tuples.
+        variance_segments: Corresponding variance arrays from
+            :func:`extract_variance_segments`.
+        std_threshold: Minimum standard deviation to keep a segment.
+            Defaults to 0.0001.
+
+    Returns:
+        A 2-tuple ``(filtered_segments, filtered_variances)`` with the
+        artifact-free data.
+    """
+    filtered_segments: List[Tuple[float, float]] = []
+    filtered_variances: List[np.ndarray] = []
+
+    for i, var_seg in enumerate(variance_segments):
+        if np.std(var_seg) >= std_threshold:
+            filtered_segments.append(segments[i])
+            filtered_variances.append(var_seg)
+
+    return filtered_segments, filtered_variances

--- a/saltup/utils/misc.py
+++ b/saltup/utils/misc.py
@@ -533,7 +533,7 @@ def compute_weighted_average(window: np.ndarray) -> float:
 
     Examples:
         >>> compute_weighted_average(np.array([1, 1, 1, 5, 5]))
-        2.6
+        2.23
     """
     if len(window) == 0:
         return np.nan

--- a/saltup/utils/misc.py
+++ b/saltup/utils/misc.py
@@ -2,10 +2,18 @@ from typing import Union, List, Iterable, Optional, Tuple
 import fnmatch
 import shutil
 import os
+from pathlib import Path
+from urllib.parse import urlparse
+import numpy as np
 from tqdm import tqdm
 from saltup.utils import configure_logging
 from contextlib import contextmanager
 import sys
+
+
+def is_url(path: Union[str, Path]) -> bool:
+    """Check if the given path is an HTTP/HTTPS URL (e.g. a presigned URL)."""
+    return isinstance(path, str) and urlparse(path).scheme in ('http', 'https')
 
 
 @contextmanager
@@ -503,3 +511,48 @@ def consolidate_files(
 
     logger.info(f"Operation completed: {processed_count} processed, {failed_count} failed")
     return processed_count, failed_count
+
+
+# =============================================================================
+# Statistical / Signal Utilities
+# =============================================================================
+
+def compute_weighted_average(window: np.ndarray) -> float:
+    """Compute a run-length-weighted average of a 1-D window.
+
+    The window is split around its median into "high" and "low" groups.
+    Each sample receives a weight equal to the length of its contiguous
+    run (high or low), so that sustained patterns contribute more.
+
+    Args:
+        window: 1-D NumPy array of values.
+
+    Returns:
+        The weighted average as a float.  Returns ``NaN`` for empty
+        arrays and the single value for length-1 arrays.
+
+    Examples:
+        >>> compute_weighted_average(np.array([1, 1, 1, 5, 5]))
+        2.6
+    """
+    if len(window) == 0:
+        return np.nan
+    if len(window) == 1:
+        return float(window[0])
+
+    median = np.median(window)
+    is_high = window > median
+
+    # Build per-element weights from contiguous run lengths
+    runs: List[int] = []
+    current_run = 1
+    for j in range(1, len(is_high)):
+        if is_high[j] == is_high[j - 1]:
+            current_run += 1
+        else:
+            runs.extend([current_run] * current_run)
+            current_run = 1
+    runs.extend([current_run] * current_run)  # last run
+
+    weights = np.array(runs, dtype=np.float64)
+    return float(np.sum(weights * window) / np.sum(weights))

--- a/saltup/utils/misc.py
+++ b/saltup/utils/misc.py
@@ -522,7 +522,7 @@ def compute_weighted_average(window: np.ndarray) -> float:
 
     The window is split around its median into "high" and "low" groups.
     Each sample receives a weight equal to the length of its contiguous
-    run (high or low), so that sustained patterns contribute more.
+    run (high or low), so that sustained trends contribute more than isolated spikes.
 
     Args:
         window: 1-D NumPy array of values.


### PR DESCRIPTION
# Add generic video & audio analysis utilities

## Why this matters

Several downstream projects built on top of **saltup** (especially video activity analysis pipelines) repeatedly implement the same low-level primitives for:

* frame preprocessing
* spatial energy extraction
* segment variance aggregation
* audio loading

This PR consolidates those reusable building blocks into the core library to reduce duplication, improve consistency across pipelines, and centralize future optimizations.

---

## Scope of changes

### `video_utils.py`

Adds generic utilities for frame preprocessing and energy extraction.

#### Frame preprocessing

* `preprocess_frame()`
  Configurable pipeline: resize → grayscale → blur → z-score normalization.

#### Grid helpers (internal)

* `_compute_grid()`
* `_quadrant_names()`

Support flexible frame partitioning into **2–16 regions**, replacing fixed-quadrant assumptions while keeping bounded complexity.

#### Energy extraction

* `extract_quadrant_energy_intensity()`
  Mean pixel intensity per grid region.

* `extract_quadrant_energy_intensity_diff()`
  Same metric computed from inter-frame absolute differences (motion-sensitive).

#### Variance utilities

* `extract_variance_segments()`
  Windowed average variance per activity segment.

* `remove_artifact_segments()`
  Filters near-constant variance segments caused by static noise or glitches.

#### Video metadata

* `get_video_properties()` now supports both:

  * local filesystem paths
  * signed URLs (remote video sources)

This enables direct usage in cloud-based pipelines without temporary file downloads.

#### Constants

* `_MIN_QUADRANTS`
* `_MAX_QUADRANTS`

---

### `audio_utils.py` (new module)

Introduces optional audio loading helpers.

* `load_audio()`
  Loads encoded (`wav/mp3/flac`) or raw PCM audio and returns mono `float32` samples in `[-1, 1]`.

* `load_audio_from_stream()`
  Equivalent loader for in-memory byte streams (e.g., S3/MinIO).

#### Dependency strategy

* `librosa` is lazily imported.
* No new mandatory dependencies.
* Audio support remains optional via:

```bash
pip install saltup[full]
```

---

### `misc.py`

* Added `compute_weighted_average()`
  Run-length-weighted averaging utility used by `extract_variance_segments()`.
